### PR TITLE
Add jiten.moe search integration

### DIFF
--- a/src/components/Line.svelte
+++ b/src/components/Line.svelte
@@ -167,6 +167,12 @@
 				console.error(`Error performing ${action} action for event ID: ${id}`, error);
 			});
 	}
+
+	function openJitenMoe() {
+		const encodedText = encodeURIComponent(line.text);
+		const url = `https://jiten.moe/parse?text=${encodedText}`;
+		window.open(url, '_blank');
+	}
 </script>
 
 {#key line.text}
@@ -245,6 +251,14 @@
 					tabindex="-1"
 				>
 					🌐
+				</button>
+				<button
+					on:click={openJitenMoe}
+					title="Parse on Jiten.moe"
+					style="background-color: #333; color: #fff; border: 1px solid #555; padding: 6px 10px; font-size: 10px; border-radius: 4px; cursor: pointer; transition: background-color 0.3s;"
+					tabindex="-1"
+				>
+					🔎
 				</button>
 			</div>
 		{/if}


### PR DESCRIPTION
Adds a lil search button:
<img width="1879" height="261" alt="image" src="https://github.com/user-attachments/assets/7f10fc35-14b7-44d4-ad52-0df6e3049b7b" />

When you click it, it takes you to Jiten.moe:
https://jiten.moe/parse?text=%E3%80%80%E3%81%9D%E3%82%8C%E3%81%8C%E5%A4%9A%E5%88%86%E3%80%81%E5%BD%93%E3%81%9F%E3%82%8A%E5%89%8D%E3%81%AE%E3%81%93%E3%81%A8%E3%81%AA%E3%82%93%E3%81%A0%E3%80%82
Which has a sentence breakdown:
<img width="1336" height="817" alt="image" src="https://github.com/user-attachments/assets/91687211-c302-456e-bd23-e2da12c78afd" />

You can then click each word / grammar and learn about it

This is kinda useful because Jiten has its own parser for Japanese, so:
1. With Yomitan you have to know where a word starts, and sometimes it's confusing
2. With full on translation it does all the hard work for you and you may not get the nuance 

I feel like this is the best of both worlds

This is a step towards https://github.com/bpwhelan/GameSentenceMiner/issues/145 except its just one button, maybe in the future we can allow the user to change the URL

# Why this over Jisho?

tbh its the same dictionary files and probably same parser, its just Jiten has game specific features like finding example sentences from games / frequency

<img width="1222" height="502" alt="image" src="https://github.com/user-attachments/assets/50c11661-6974-4da6-b48c-24d0d641d9c3" />
